### PR TITLE
[bugfix|Table]修复prevProps.rowSelection.selectedRowKeys取不到的问题

### DIFF
--- a/source/components/Table/Table.tsx
+++ b/source/components/Table/Table.tsx
@@ -291,8 +291,14 @@ class Table<T> extends React.Component<TableProps<T>, TableState<T>> {
   }
 
   componentDidUpdate(prevProps: TableProps<T>) {
-    if (this.props.rowSelection && 'selectedRowKeys' in this.props.rowSelection &&
-      !isEqual(this.props.rowSelection.selectedRowKeys, prevProps.rowSelection.selectedRowKeys)) {
+    if (
+      this.props.rowSelection && 'selectedRowKeys' in this.props.rowSelection &&
+      (
+        !prevProps.rowSelection || 
+        !prevProps.rowSelection.selectedRowKeys || 
+        !isEqual(this.props.rowSelection.selectedRowKeys, prevProps.rowSelection.selectedRowKeys)
+      )) 
+    {
       this.store.setState({
         selectedRowKeys: this.props.rowSelection.selectedRowKeys || [],
       });


### PR DESCRIPTION
修复prevProps.rowSelection.selectedRowKeys取不到的问题。
比如使用Table组建时一开始没给rowSelection值，一些操作后给了rowSelection值以及selectedRowKeys值，就会出现这个bug，因为prevProps.rowSelection是undefined。