### PR TITLE
fix(Upload): avoid exposing error to global when option.action is rejected

### DIFF
--- a/source/components/Upload/src/AjaxUploader.js
+++ b/source/components/Upload/src/AjaxUploader.js
@@ -7,7 +7,7 @@ import defaultRequest from './request';
 import getUid from './uid';
 import attrAccept from './attr-accept';
 import traverseFileTree from './traverseFileTree';
-
+const noop = () => {}
 class AjaxUploader extends Component {
   static propTypes = {
     component: PropTypes.string,
@@ -162,7 +162,7 @@ class AjaxUploader extends Component {
         },
       });
       onStart(file);
-    });
+    }).catch(noop);
   }
 
   reset() {


### PR DESCRIPTION
Upload 组件的 action 选项两种类型的数据：string 和 Promise。

经过测试：

1. 当 action `resolved` 是，执行上传操作，
2. 当 action `rejected` 时，由于未进行捕获，导致异常抛到全局。

一般在业务场景中，会根据所上传的文件进行前置判断和提示，所以组件内应该对此处抛出的 error 进行捕获。

