### PR TITLE
fix(Tabs): remove tabs warning

### DIFF
--- a/source/components/Tabs/index.tsx
+++ b/source/components/Tabs/index.tsx
@@ -145,11 +145,6 @@ export default class Tabs extends React.Component<TabsProps, any> {
       tabPaneAnimated = 'animated' in this.props ? tabPaneAnimated : false;
     }
 
-    warning(
-      !(type.indexOf('card') >= 0 && (size === 'small' || size === 'large')),
-      "Tabs[type=card|editable-card] doesn't have small or large size, it's by designed."
-    );
-
     const cls = classNames(className, {
       [`${prefixCls}-vertical`]: tabPosition === 'left' || tabPosition === 'right',
       [`${prefixCls}-${size}`]: !!size,


### PR DESCRIPTION
项目使用中发现当 type=card|editable-card 时，指定 size 对最终展示有实际作用，所以去掉 Tabs 实现中的对于指定 size 的警告。