### PR TITLE
修复相同大小的图片切换时，容器上移问题

### DIFF
--- a/source/components/PicturePreview/index.tsx
+++ b/source/components/PicturePreview/index.tsx
@@ -384,7 +384,7 @@ class PicturePreview extends Component<PicturePreviewProps, PicturePreviewState>
           width: num2px(width),
           height: num2px(height),
           left: num2px(oriLeft + (oriWidth - width) / 2),
-          top: num2px(oriTop + (oriHeight - height) / 2)
+          top: num2px(oriTop + Math.trunc((oriHeight - height) / 2))
         };
 
         this.setState({


### PR DESCRIPTION
计算容器的top位置时，由于偏移量计算问题导致每次容器的top都会变小